### PR TITLE
Fix UUID deprecation warning

### DIFF
--- a/generators/stringGenerator.js
+++ b/generators/stringGenerator.js
@@ -1,7 +1,7 @@
 const randomNumber = require('./randomNumberGenerator')
 const fakerGenerator = require('./fakerGenerator')
 
-const uuidv1 = require('uuid/v1')
+const uuidv4 = require('uuid').v4;
 const btoa = require('btoa')
 
 /**
@@ -47,7 +47,7 @@ module.exports = (schemaPart, schemaName) => {
       case 'email':
         return randomString(randomNumber(10, 15)) + '@' + randomString(randomNumber(10, 15)) + '.com'
       case 'uuid':
-        return uuidv1()
+        return uuidv4()
       case 'uri':
         return 'https://www.' + randomString(randomNumber(10, 15)) + '.com'
       case 'hostname':

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it-mockers",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,9 +15,9 @@
       "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
     },
     "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "url": "https://github.com/acrontum/generate-it-mockers"
   },
   "dependencies": {
+    "btoa": "^1.2.1",
     "faker": "^4.1.0",
-    "uuid": "^7.0.3",
-    "btoa": "^1.2.1"
+    "uuid": "^8.3.2"
   },
   "author": "Acrontum GmbH",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {}
 }


### PR DESCRIPTION
Seeing deprecation warnings everywhere now:
```
(node:75068) DeprecationWarning: Deep requiring like `const uuidv1 = require('uuid/v1');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.
```